### PR TITLE
Fix null refs on Type.Name

### DIFF
--- a/src/StringDedupAnalyzer/Program.cs
+++ b/src/StringDedupAnalyzer/Program.cs
@@ -38,7 +38,7 @@
                     int? objGen = GenerationOf(heap, obj);
                     if (objGen == 2)
                     {
-                        if (obj.Type.Name.Equals("System.String"))
+                        if (obj.Type.Name?.Equals("System.String") == true)
                         {
                             // This are all the strings in gen2, they may or may not be live, they may or may not have a gen 2 reference.
                             // This should give an idea why strings are important
@@ -52,7 +52,7 @@
                             // This happen when we see a string referenced by a gen2 object
                             if (refGen == 2)
                             {
-                                if (referencedObject.Type.Name.Equals("System.String"))
+                                if (referencedObject.Type.Name?.Equals("System.String") == true)
                                 {
                                     if (detailed)
                                     {


### PR DESCRIPTION
It turns out `Type.Name`can be null - this prevented me analyzing some dumps from the Stack Overflow application pools. Since we don't care about non-strings, we can just ignore the case.

Exceptions before this:
```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at DumpStrings.Program.Main(String[] args) in C:\Nick\StringDedupAnalyzer\src\StringDedupAnalyzer\Program.cs:line 41
```
```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at DumpStrings.Program.Main(String[] args) in C:\Nick\StringDedupAnalyzer\src\StringDedupAnalyzer\Program.cs:line 55
```