### PR TITLE
Compute the size of large strings correctly

### DIFF
--- a/src/StringDedupAnalyzer/Program.cs
+++ b/src/StringDedupAnalyzer/Program.cs
@@ -44,7 +44,7 @@
                             // This should give an idea why strings are important
                             // My prediction is that this should be a significant percentage (otherwise why bother?)
                             gen2StringCount++;
-                            gen2StringSize += obj.AsString().Length * 2;
+                            gen2StringSize += obj.AsString(int.MaxValue).Length * 2;
                         }
                         foreach (ClrObject referencedObject in obj.EnumerateReferences())
                         {
@@ -63,7 +63,7 @@
                                     // This should give an idea how much work we need to do to scan these strings
                                     // My assumption is that the majority of the work is the computing of the hash code, that why
                                     // the cost should be roughly corresponding to the total length of the strings
-                                    string referencedObjectAsString = referencedObject.AsString();
+                                    string referencedObjectAsString = referencedObject.AsString(int.MaxValue);
                                     gen2ScanStringCount++;
                                     gen2ScanStringSize += referencedObjectAsString.Length * 2;
                                     // This happen when we see a gen2 string referenced by a gen2 object


### PR DESCRIPTION
Turn out `ClrObject.AsString()` has a non-intuitive default value parameter named maxLength and is default to 4096.

https://github.com/microsoft/clrmd/blob/0217b2cc1ae11b58790fa2e08a4bb7664fd01700/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs#L279-L286

The end result of this problem is that all long strings are capped to 4096 (or 8192 bytes).

The fix should eliminate the problem.