### PR TITLE
Add Illyriad Chat Server numbers

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -2,3 +2,4 @@ application,gen2size,gen2stringsize,gen2stringcount,gen2scanstringsize,gen2scans
 string,65680,12844,66,9866,33,30,1,before deduplication
 string,65680,12844,66,9866,33,0,0,after deduplication
 Stack Overflow Mobile API,20481623272,2682685688,86181864,3411517306,103209992,2099367310,84041766,Initial Run
+Illyriad Chat Server,59274144,24912274,139175,26323520,174716,7547920,68694,ASP NET Core 3.1+SignalR (<24hr uptime)


### PR DESCRIPTION
Wasn't expecting much, so 68k duplicated strings is a surprise!
```
Gen 2 size         : 59274144
Gen 2 strings      : 24912274 bytes out of 139175 strings
Gen 2 scan string  : 26323520 bytes out of 174716 strings
Gen 2 dup string   : 7547920 bytes out of 68694 strings
59274144,24912274,139175,26323520,174716,7547920,68694
```